### PR TITLE
add k_velocity_value:= 5 to launch file for simulation

### DIFF
--- a/march_simulation/launch/march_world.launch
+++ b/march_simulation/launch/march_world.launch
@@ -9,7 +9,7 @@
 
   <!-- Load the URDF into the ROS Parameter Server -->
   <param name="robot_description"
-          command="$(find xacro)/xacro --inorder '$(find march_description)/urdf/march-iv.xacro'" />
+          command="$(find xacro)/xacro --inorder '$(find march_description)/urdf/march-iv.xacro' k_velocity_value:=5.0" />
 
   <rosparam file="$(find march_simulation)/config/config_march-iv.yaml" command="load"/>
 

--- a/march_simulation/launch/march_world.launch
+++ b/march_simulation/launch/march_world.launch
@@ -9,7 +9,8 @@
 
   <!-- Load the URDF into the ROS Parameter Server -->
   <param name="robot_description"
-          command="$(find xacro)/xacro --inorder '$(find march_description)/urdf/march-iv.xacro' k_velocity_value:=5.0" />
+          command="$(find xacro)/xacro --inorder '$(find march_description)/urdf/march-iv.xacro'
+          k_velocity_value:=10.0 max_effort_value:=10.0" />
 
   <rosparam file="$(find march_simulation)/config/config_march-iv.yaml" command="load"/>
 


### PR DESCRIPTION
closes #13 

launch file changes k_velocity_value, ensuring that realistic simulation values are generated at start up. The simulation will no longer have erratic movement when starting up. 