### PR TITLE
add trajectory constraints to march-iv controller yaml in simulation

### DIFF
--- a/march_simulation/config/config_march-iv.yaml
+++ b/march_simulation/config/config_march-iv.yaml
@@ -32,3 +32,21 @@ march:
       state_publish_rate:  25            # Override default
       action_monitor_rate: 30            # Override default
       stop_trajectory_duration: 0        # Override default
+
+      constraints:
+        left_hip_aa:
+          trajectory: 0.2
+        left_hip_fe:
+          trajectory: 0.2
+        left_knee:
+          trajectory: 0.2
+        left_ankle:
+          trajectory: 0.2
+        right_hip_aa:
+          trajectory: 0.2
+        right_hip_fe:
+          trajectory: 0.2
+        right_knee:
+          trajectory: 0.2
+        right_ankle:
+          trajectory: 0.2


### PR DESCRIPTION
adding trajectory constraints so that march_safety is able to work in simulation