### PR TITLE
Joint order in published messages

### DIFF
--- a/march_simulation/config/config_march-iv.yaml
+++ b/march_simulation/config/config_march-iv.yaml
@@ -9,45 +9,45 @@ march:
     trajectory:
       type: "effort_controllers/JointTrajectoryController"
       joints:
+        - left_ankle
         - left_hip_aa
         - left_hip_fe
         - left_knee
-        - left_ankle
+        - right_ankle
         - right_hip_aa
         - right_hip_fe
         - right_knee
-        - right_ankle
 
       gains: # Required because we're controlling an effort interface
         # The pid values are working, but they seem to be heavily dependent
         # on the max effort values (in the march_world.launch file) for reasons unknown.
+        left_ankle: {p: 1000,  d: 10, i: 0, i_clamp: 0}
         left_hip_aa: {p: 1000,  d: 10, i: 0, i_clamp: 0}
         left_hip_fe: {p: 1000,  d: 10, i: 0, i_clamp: 0}
         left_knee: {p: 1000,  d: 10, i: 0, i_clamp: 0}
-        left_ankle: {p: 1000,  d: 10, i: 0, i_clamp: 0}
+        right_ankle: {p: 1000,  d: 10, i: 0, i_clamp: 0}
         right_hip_aa: {p: 1000,  d: 10, i: 0, i_clamp: 0}
         right_hip_fe: {p: 1000,  d: 10, i: 0, i_clamp: 0}
         right_knee: {p: 1000,  d: 10, i: 0, i_clamp: 0}
-        right_ankle: {p: 1000,  d: 10, i: 0, i_clamp: 0}
 
       state_publish_rate:  25            # Override default
       action_monitor_rate: 30            # Override default
       stop_trajectory_duration: 0        # Override default
 
       constraints:
+        left_ankle:
+          trajectory: 0.2
         left_hip_aa:
           trajectory: 0.2
         left_hip_fe:
           trajectory: 0.2
         left_knee:
           trajectory: 0.2
-        left_ankle:
+        right_ankle:
           trajectory: 0.2
         right_hip_aa:
           trajectory: 0.2
         right_hip_fe:
           trajectory: 0.2
         right_knee:
-          trajectory: 0.2
-        right_ankle:
           trajectory: 0.2


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

(Partially) Closes PM-72

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
Currently a lot of messages contain information per joint. The order of the joints differs per message type, this is inconvenient when looking in the log files or when the files are converted. This PR fixes the the order of some messages such that all messages will have the order: 
-left ankle
-left hip aa
-left hip fe
-left knee
-right ankle
-right hip aa
-right hip fe
-right knee

A similar PR will follow for the hardware-interface, however this has to be tested on the exoskeleton first. The order of all messages (simulation and exoskeleton) will then have the same joint order.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
The order of the joint names in the configuration file of the simulation have been changed. 
<!-- Please don't forget to request for reviews -->
