### PR TITLE
Tune the max effort values for the simulation.

### DIFF
--- a/march_simulation/launch/march_world.launch
+++ b/march_simulation/launch/march_world.launch
@@ -8,11 +8,14 @@
   <arg name="debug" default="false"/>
 
   <!-- Load the URDF into the ROS Parameter Server -->
-  <!-- Override effort values as Gazebo uses different units than the actual hardware. -->
-  <!-- If the controller is properly tuned, these values can be arbitrarily large. -->
+  <!-- Override effort values as Gazebo uses different units than the actual IMC. -->
+  <!-- In theory, if the controller is properly tuned, these values can be arbitrarily large. -->
+  <!-- However, to limit the safety controller, we need to limit them. -->
     <param name="robot_description"
-            command="$(find xacro)/xacro --inorder '$(find march_description)/urdf/march-iv-simulation.xacro'
-            k_velocity_value:=10000.0 k_position_value:=20000.0 max_effort_rotary:=20000.0 max_effort_linear:=50000.0" />
+            command="$(find xacro)/xacro --inorder '$(find march_description)/urdf/march-iv.xacro'
+            k_velocity_value_rotary:=60.0 k_velocity_value_linear:=60.0
+            k_position_value_rotary:=50.0 k_position_value_linear:=50.0
+            max_effort_rotary:=200.0 max_effort_linear:=70.0" />
 
   <!-- Upload the controller configuration -->
   <rosparam file="$(find march_simulation)/config/config_march-iv.yaml" command="load"/>


### PR DESCRIPTION
Related to https://github.com/project-march/march/pull/386

<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-101

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->

Tune the max effort values for the simulation. This prevents safety controller from glitching, allowing replacement of endstops. As a result, the simulation and exo can use the same URDF again.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

* Discovered that the safety controller will cause problems without appropriate max effort values. 
* Max effort values of simulation tuned.
* Simulation URDF deleted.
* Simulation now hangs in the air by default.

<!-- Please don't forget to request for reviews -->
