### PR TITLE
Fix all compiler warnings and turn them into errors

### DIFF
--- a/march_fake_sensor_data/CMakeLists.txt
+++ b/march_fake_sensor_data/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(march_fake_sensor_data)
 
-add_compile_options(-std=c++11 -Wall -g)
+add_compile_options(-std=c++14 -Wall -Wextra -Werror)
 
 find_package(catkin REQUIRED COMPONENTS
     dynamic_reconfigure

--- a/march_fake_sensor_data/src/FakeTemperatureData.cpp
+++ b/march_fake_sensor_data/src/FakeTemperatureData.cpp
@@ -48,7 +48,7 @@ double calculateArTemperature(std::vector<int> temperatures, std::vector<float> 
  * @param config the config file with all the parameters
  * @param level A bitmask
  */
-void temperatureConfigCallback(march_fake_sensor_data::TemperaturesConfig& config, uint32_t level)
+void temperatureConfigCallback(march_fake_sensor_data::TemperaturesConfig& config, uint32_t /* level */)
 {
   // Make sure there is always a possible interval between min and max
   // temperature.

--- a/march_gazebo_plugins/CMakeLists.txt
+++ b/march_gazebo_plugins/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 project(march_gazebo_plugins)
 
+add_compile_options(-std=c++14 -Wall -Wextra -Werror)
+
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
         gazebo_ros


### PR DESCRIPTION

## Description
Fixed compiler warning and turned warnings into errors.

## Changes
* Fix compiler warning
* Add `-Wextra` to enable more warnings
* Add `-Werror` to turn warnings into errors
* Add `-std=c++14` to compile with c++14 standard


<!-- Please don't forget to request for reviews -->
