### PR TITLE
Remove xacro in-order processing

### DIFF
--- a/march_simulation/launch/march_world.launch
+++ b/march_simulation/launch/march_world.launch
@@ -13,7 +13,7 @@
     <!-- In theory, if the controller is properly tuned, these values can be arbitrarily large. -->
     <!-- However, to limit the safety controller, we need to limit them. -->
     <param name="robot_description"
-           command="$(find xacro)/xacro --inorder '$(find march_description)/urdf/$(arg robot).xacro'
+           command="$(find xacro)/xacro '$(find march_description)/urdf/$(arg robot).xacro'
                     k_velocity_value_rotary:=60.0 k_velocity_value_linear:=60.0
                     k_position_value_rotary:=50.0 k_position_value_linear:=50.0
                     max_effort_rotary:=200.0 max_effort_linear:=40.0


### PR DESCRIPTION
## Description
Removed xacro `inorder` processing, which became the default since ROS Lunar. In the simulation we cannot use the URDF built by `march_description`, since we need to pass the arguments.


<!-- Please don't forget to request for reviews -->
