### PR TITLE
Add parameters for k-values for all joints

### DIFF
--- a/march_simulation/launch/march_world.launch
+++ b/march_simulation/launch/march_world.launch
@@ -14,8 +14,10 @@
     <!-- However, to limit the safety controller, we need to limit them. -->
     <param name="robot_description"
            command="$(find xacro)/xacro --inorder '$(find march_description)/urdf/$(arg robot).xacro'
-                    k_velocity_value_rotary:=60.0 k_velocity_value_linear:=60.0
-                    k_position_value_rotary:=50.0 k_position_value_linear:=50.0
+                    k_velocity_value_hfe:=60.0 k_velocity_value_kfe:=60.0
+                    k_velocity_value_haa:=60.0 k_velocity_value_adpf:=60.0
+                    k_position_value_hfe:=50.0 k_position_value_kfe:=50.0
+                    k_position_value_haa:=50.0 k_position_value_adpf:=50.0
                     max_effort_rotary:=200.0 max_effort_linear:=40.0
                     ground_gait:=$(arg ground_gait)" />
 


### PR DESCRIPTION

## Description
Since project-march/march#470 the ankle started to wiggle in the simulation, since it got incorrect k-values, which were meant for the real exoskeleton. I fixed this by adding parameters for k-values for all joints.

## Changes
* Add `k_position` and `k_velocity` parameters for all joints

<!-- Please don't forget to request for reviews -->
