### PR TITLE
Set the paused argument in the gazebo empty_world.launch to False

### DIFF
--- a/march_simulation/launch/march_world.launch
+++ b/march_simulation/launch/march_world.launch
@@ -41,7 +41,7 @@
             <arg name="world_name" value="$(find march_simulation)/worlds/march.world"/>
             <arg name="debug" value="$(arg debug)" />
             <arg name="gui" value="$(arg gazebo_ui)" />
-            <arg name="paused" value="true"/>
+            <arg name="paused" value="false"/>
             <arg name="use_sim_time" value="$(arg use_sim_time)"/>
             <arg name="verbose" value="true" />
         </include>

--- a/march_simulation/launch/march_world.launch
+++ b/march_simulation/launch/march_world.launch
@@ -7,6 +7,7 @@
     <arg name="ground_gait" default="false" doc="Exoskeleton will ground gait if true."/>
     <arg name="obstacle" default="none" doc="Obstacle to load in the simulation."/>
     <arg name="robot" default="march4" doc="The robot to run. Can be: march3, march4, test_joint_rotational."/>
+    <arg name="balance" default="false" doc="Uses the dynamic balance gaits instead of the predefined gaits."/>
 
     <!-- Load the URDF into the ROS Parameter Server -->
     <!-- Override effort values as Gazebo uses different units than the actual IMC. -->
@@ -41,7 +42,7 @@
             <arg name="world_name" value="$(find march_simulation)/worlds/march.world"/>
             <arg name="debug" value="$(arg debug)" />
             <arg name="gui" value="$(arg gazebo_ui)" />
-            <arg name="paused" value="false"/>
+            <arg name="paused" value="$(eval not balance)"/>
             <arg name="use_sim_time" value="$(arg use_sim_time)"/>
             <arg name="verbose" value="true" />
         </include>


### PR DESCRIPTION

## Description
In order to properly launch the moveit package the simulation time **must** be active otherwise the movegroups will not be initialized. If the movegroups are not initialised the init of the gait selection is not finished causing the state machine to be stuck waiting for the gait selection which will not be finished. Therefore the paused argument must be false. This will not cause any weird behavior of the simulation because the physics are loaded after the state machine is initialized. 

 
## Changes
* Set paused argument to false