### PR TITLE
Update the frequency of the transorm publisher

### DIFF
--- a/march_simulation/scripts/to_world_transform
+++ b/march_simulation/scripts/to_world_transform
@@ -22,7 +22,8 @@ world_properties_request = GetWorldPropertiesRequest()
 model = GetModelStateRequest()
 model.model_name = model_name
 
-rate = rospy.Rate(10)
+# set this rate equal to the rate of the joint state publisher, such that the TF frames are updated at the same rate.
+rate = rospy.Rate(50)
 
 while not rospy.is_shutdown() and model_name not in get_world_properties(world_properties_request).model_names:
     try:


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->


## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
Capture point was quite wiggly, which was of course not so beneficial. One of the reasons was that the joint state publisher and the script publishing the transform from the robot to the world were not publishing at the same rate. This means that the center of mass was updated although TF was only partially updated. This was not a big deal, but when we differentiate this for capture point we get a noisy signal. So ideally the two rates are equal. That does not take away all the noise, but there will be another PR in the march repo with a robust way of differentiating. 
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
Change the frequency of the transform publisher from 10 to 50 and add a comment about it. 
<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
