### PR TITLE
Replace controller spawner for manager

### DIFF
--- a/march_simulation/launch/march_world.launch
+++ b/march_simulation/launch/march_world.launch
@@ -26,8 +26,9 @@
     <rosparam file="$(find march_simulation)/config/$(arg robot).yaml" command="load"/>
 
     <group ns="march">
-        <node name="controller_spawner" pkg="controller_manager" type="spawner"
-              args="controller/trajectory joint_state_controller"/>
+        <node name="controller_spawner" pkg="controller_manager" type="controller_manager"
+              respawn="false" output="screen"
+              args="spawn controller/trajectory joint_state_controller"/>
 
         <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
         <node name="upload_joint_names" pkg="march_simulation" type="upload_joint_names"/>


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
In the hardware-interface, we have replaced the `controller_spawner` with the `controller_manager` to prevent the controllers from being unloaded. Now for Gazebo this has also been an issue, because Gazebo would hang when trying to unload the controllers. So with this script the controllers are no longer trying to be unloaded via the service, which allows Gazebo to be shutdown correctly :tada: 

## Changes
* Replace `controller_spawner` with `controller_manager` script

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
