### PR TITLE
Add missing runtime dependency in simulation

### DIFF
--- a/march_simulation/package.xml
+++ b/march_simulation/package.xml
@@ -11,6 +11,7 @@
     <exec_depend>controller_manager</exec_depend>
     <exec_depend>gazebo_msgs</exec_depend>
     <exec_depend>gazebo_ros</exec_depend>
+    <exec_depend>gazebo_ros_control</exec_depend>
     <exec_depend>geometry_msgs</exec_depend>
     <exec_depend>joint_state_controller</exec_depend>
     <exec_depend>joint_trajectory_controller</exec_depend>


### PR DESCRIPTION

<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
This PR fixes errors in rviz such as "No transform from [foot_left] to [world]"
in that are sometimes caused by the absence of this dependency.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
Add `gazebo_ros_control` as a runtime dependency for simulation package.

## Testing
1. Run `sudo apt remove ros-melodic-gazebo-ros-control` to remove this dependency
2. Start the simulation with `roslaunch march_launch march_simulation.launch`
3. Add the robot model and notice that it is not loaded correctly.
4. Run `rosdep install -y --from-paths src  --ignore-src` to install the missing dependency.
5. Start the simulation again and verify that the model is now loaded correctly.

<!-- Provide additional information necessary for testing this PR. This includes details like branches in other repos, launch arguments or gait directories. In the case of a bug fix, provide the steps to reproduce the bug.-->

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
